### PR TITLE
Redirect stripe success fail

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -16,8 +16,8 @@ class PaymentsController < ApplicationController
     currency: 'aud',
     quantity: 1,
     }],
-    success_url: 'http://localhost:3000/',
-    cancel_url: 'http://localhost:3000/',
+    success_url: "http://localhost:3000/services/#{params[:service_id]}/proposals/#{params[:proposal_id]}/payment/success",
+    cancel_url: "http://localhost:3000//services/#{params[:service_id]}"
     )
   end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -85,4 +85,10 @@ class ServicesController < ApplicationController
       redirect_to service_path(service.id)
     end
   end
+
+  def job_paid
+    service = Service.find(params[:service_id])
+    service.paid_on = DateTime.now
+    service.save
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -11,4 +11,9 @@ class Service < ApplicationRecord
         proposals.count > 0 ? proposals.sum(:price) / proposals.count : 0
     end
     
+    def open_for_proposals?
+        return false if completed_on != nil
+        proposals.each { |p| return false if p.accepted == true }
+        return true
+    end
 end

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -2,7 +2,7 @@
   <h3>For: <%=@service.user.fullname%></h3>
     <p>Job: <%=@service.title%></p>
     <p>by: <%=@proposal.user.fullname%></p>
-    <p>price: <%=@proposal.price / 100.0%></p>
+    <p>price: $<%=@proposal.price / 100.0%></p>
 <button id="pay-now">Pay now
     <script src="https://js.stripe.com/v3/"></script>
 </button>

--- a/app/views/services/job_paid.html.erb
+++ b/app/views/services/job_paid.html.erb
@@ -1,0 +1,1 @@
+<p>Job paid</p>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -42,10 +42,10 @@
             <p>My proposal: <%= number_to_currency(@my_proposal.price / 100.0, precision: 2) %></p>
             <p>Notes:</p>
             <p><%= @my_proposal.notes %></p>
-            <% if @my_proposal.accepted == true %>
-                <p>Your proposal has been accepted!</p>
+            <% if @my_proposal.accepted != nil %>
+                <p><%= "Your proposal " + (@my_proposal.accepted == false ? "has been rejected" : "has been accepted") %></p>
             <% else %>
-                <p><%= "Your proposal " + (@my_proposal.accepted == false ? "has been rejected" : "is pending approval") %></p>
+                <p>Your proposal is pending approval</p>
                 <%= link_to "Edit", edit_service_proposal_path(@service.id) %>
                 <%= link_to "Withdraw", service_proposal_path(@service.id), method: :delete, data: {confirm: "Are you sure? This action cannot be undone."} %>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get 'services/:id/mark_complete', to: 'services#complete_service', as: 'complete_service'
   patch 'services/:service_id/proposals/:id/accept', to: 'proposals#accept', as: 'accept_proposal'
   get 'proposals', to: 'proposals#index', as: 'proposals'
+  get 'services/:service_id/proposals/:proposal_id/payment/success', to: 'services#job_paid'
   devise_for :users
   root to: 'home#index'
   resources :services do


### PR DESCRIPTION
@loui7 I've set up the payment success to redirect to a page, this would be the ideal place to implement a rating scale. Could look into using a range/slider, it's a good way to give a user an option for ratings rather than asking for a number. `http://localhost:3000/services/34/proposals/2/payment/success` is the path successes will go to - the action is `job_paid` in `services_controller.rb`. Have checked in with Matt previously and he said saving data in this get request is ok given the limitations of Stripe.